### PR TITLE
Add text-based transformer tasks

### DIFF
--- a/nodes/task_list_tpl.py
+++ b/nodes/task_list_tpl.py
@@ -28,6 +28,9 @@ class TaskListTpl:
             "image-to-text",
             "image-text-to-text",
             "visual-question-answering",
+            "question-answering",
+            "summarization",
+            "translation",
         ]
 
     def select_task(self, task_list):  # fix for task_name to task_list


### PR DESCRIPTION
## Summary
- extend `TaskListTpl` to include common text-based pipeline tasks
- keep only question-answering, summarization, and translation

## Testing
- `python -m py_compile nodes/task_list_tpl.py`


------
https://chatgpt.com/codex/tasks/task_e_686743730f5083329cc85ab7546ca4ed